### PR TITLE
Add LSM6DSL driver support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ GeneratedFiles/
 *.pro.user*
 .DS_store
 octave-core
+.vscode

--- a/Linux/RTIMULibDrive/Makefile
+++ b/Linux/RTIMULibDrive/Makefile
@@ -28,8 +28,8 @@ RTIMULIBPATH  = ../../RTIMULib
 CC    			= gcc
 CXX   			= g++
 DEFINES       	=
-CFLAGS			= -pipe -O2 -Wall -W $(DEFINES)
-CXXFLAGS      	= -pipe -O2 -Wall -W $(DEFINES)
+CFLAGS			= -pipe  -Wall -W $(DEFINES) -g
+CXXFLAGS      	= -pipe  -Wall -W $(DEFINES) -g
 INCPATH       	= -I. -I$(RTIMULIBPATH)
 LINK  			= g++
 LFLAGS			= -Wl,-O1
@@ -61,6 +61,7 @@ DEPS    = $(RTIMULIBPATH)/RTMath.h \
     $(RTIMULIBPATH)/RTFusion.h \
     $(RTIMULIBPATH)/RTFusionKalman4.h \
     $(RTIMULIBPATH)/RTFusionRTQF.h \
+	$(RTIMULIBPATH)/RTFusionComplimentary.h \
     $(RTIMULIBPATH)/RTIMUSettings.h \
     $(RTIMULIBPATH)/RTIMUAccelCal.h \
     $(RTIMULIBPATH)/RTIMUMagCal.h \
@@ -76,12 +77,15 @@ DEPS    = $(RTIMULIBPATH)/RTMath.h \
     $(RTIMULIBPATH)/IMUDrivers/RTIMULSM9DS1.h \
     $(RTIMULIBPATH)/IMUDrivers/RTIMUBMX055.h \
     $(RTIMULIBPATH)/IMUDrivers/RTIMUBNO055.h \
+	$(RTIMULIBPATH)/IMUDrivers/RTIMULSM6DSLLIS3MDL.h \
+	$(RTIMULIBPATH)/IMUDrivers/RTIMULSM6DSLMap.h \
     $(RTIMULIBPATH)/IMUDrivers/RTPressure.h \
     $(RTIMULIBPATH)/IMUDrivers/RTPressureBMP180.h \
     $(RTIMULIBPATH)/IMUDrivers/RTPressureLPS25H.h \
     $(RTIMULIBPATH)/IMUDrivers/RTPressureMS5611.h \
     $(RTIMULIBPATH)/IMUDrivers/RTPressureMS5637.h \
-    $(RTIMULIBPATH)/IMUDrivers/RTIMUHMC5883LADXL345.h
+    $(RTIMULIBPATH)/IMUDrivers/RTIMUHMC5883LADXL345.h \
+	
 
 OBJECTS = objects/RTIMULibDrive.o \
     objects/RTMath.o \
@@ -89,6 +93,7 @@ OBJECTS = objects/RTIMULibDrive.o \
     objects/RTFusion.o \
     objects/RTFusionKalman4.o \
     objects/RTFusionRTQF.o \
+	objects/RTFusionComplimentary.o \
     objects/RTIMUSettings.o \
     objects/RTIMUAccelCal.o \
     objects/RTIMUMagCal.o \
@@ -103,6 +108,7 @@ OBJECTS = objects/RTIMULibDrive.o \
     objects/RTIMULSM9DS1.o \
     objects/RTIMUBMX055.o \
     objects/RTIMUBNO055.o \
+	objects/RTIMULSM6DSLLIS3MDL.o \
     objects/RTPressure.o \
     objects/RTPressureBMP180.o \
     objects/RTPressureLPS25H.o \

--- a/RTIMULib/IMUDrivers/RTIMU.cpp
+++ b/RTIMULib/IMUDrivers/RTIMU.cpp
@@ -25,6 +25,7 @@
 #include "RTIMU.h"
 #include "RTFusionKalman4.h"
 #include "RTFusionRTQF.h"
+#include "RTFusionComplimentary.h"
 
 #include "RTIMUNull.h"
 #include "RTIMUMPU9150.h"
@@ -37,6 +38,7 @@
 #include "RTIMUBMX055.h"
 #include "RTIMUBNO055.h"
 #include "RTIMUHMC5883LADXL345.h"
+#include "RTIMULSM6DSLLIS3MDL.h"
 
 //  this sets the learning rate for compass running average calculation
 
@@ -120,6 +122,9 @@ RTIMU *RTIMU::createIMU(RTIMUSettings *settings)
     case RTIMU_TYPE_HMC5883LADXL345:
 	    return new RTIMU5883L(settings);
 
+    case RTIMU_TYPE_LSM6DSLLIS3MDL:
+        return new RTIMULSM6DSLLIS3MDL(settings);
+
     case RTIMU_TYPE_AUTODISCOVER:
         if (settings->discoverIMU(settings->m_imuType, settings->m_busIsI2C, settings->m_I2CSlaveAddress)) {
             settings->saveSettings();
@@ -160,6 +165,10 @@ RTIMU::RTIMU(RTIMUSettings *settings)
 
     case RTFUSION_TYPE_RTQF:
         m_fusion = new RTFusionRTQF();
+        break;
+
+    case RTFUSION_TYPE_COMPLIMENTARY:
+        m_fusion = new RTFusionComplimentary();
         break;
 
     default:

--- a/RTIMULib/IMUDrivers/RTIMUDefs.h
+++ b/RTIMULib/IMUDrivers/RTIMUDefs.h
@@ -44,6 +44,7 @@
 #define RTIMU_TYPE_BMX055                   9                   // Bosch BMX055
 #define RTIMU_TYPE_BNO055                   10                  // Bosch BNO055
 #define RTIMU_TYPE_HMC5883LADXL345          11                  // HMC5883L with ADXL345 and L3G4200D
+#define RTIMU_TYPE_LSM6DSLLIS3MDL           12                  // LSM6DSL with LIS3MDL
 //----------------------------------------------------------
 //
 //  MPU-9150
@@ -1159,3 +1160,32 @@
 #define BNO055_PWR_MODE_NORMAL      0x00
 
 #endif // _RTIMUDEFS_H
+
+
+//----------------------------------------------------------
+//
+//  LSM6DSL
+
+#define LSM6DSL_ADDRESS0             0x6a
+#define LSM6DSL_ADDRESS1             0x6b   
+#define LSM6DSL_ID                   0x6a
+
+// Required registers for auto-discover
+#define LSM6DSL_WHO_AM_I             0x0f
+
+// just define defaults here
+#define LSM6DSL_GYRO_SAMPLERATE_208 5
+#define LSM6DSL_GYRO_FSR_250        1
+#define LSM6DSL_GYRO_LPF_OFF       -1
+#define LSM6DSL_GYRO_HPF_OFF       -1
+
+#define LSM6DSL_ACCEL_SAMPLERATE_208    5
+#define LSM6DSL_ACCEL_FSR_2             0
+#define LSM6DSL_ACCEL_LPF1_HALF_ODR     0
+#define LSM6DSL_ACCEL_AN_LPF_1500       0
+#define LSM6DSL_ACCEL_FILTER_BYPASS     0
+
+#define LSM6DSL_POLLING_MODE_CACHE_OFF  0
+
+#define LSM6DSL_FIFO_MODE_BYPASS        0
+#define LSM6DSL_FIFO_SAMPLERATE_208     5

--- a/RTIMULib/IMUDrivers/RTIMULSM6DSLLIS3MDL.cpp
+++ b/RTIMULib/IMUDrivers/RTIMULSM6DSLLIS3MDL.cpp
@@ -1,0 +1,275 @@
+////////////////////////////////////////////////////////////////////////////
+//
+//  This file is part of RTIMULib
+//
+//  Copyright (c) 2014-2015, richards-tech, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+//  Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+#include "RTIMULSM6DSLLIS3MDL.h"
+
+using namespace LSM6DSL;
+
+RTIMULSM6DSLLIS3MDL::RTIMULSM6DSLLIS3MDL(RTIMUSettings *settings) : RTIMU(settings)
+{}
+
+RTIMULSM6DSLLIS3MDL::~RTIMULSM6DSLLIS3MDL()
+{}
+
+bool RTIMULSM6DSLLIS3MDL::IMUInit()
+{
+
+    m_gyroAccelSlaveAddr = m_settings->m_I2CSlaveAddress;
+
+    setCalibrationData();
+
+    if (!m_settings->HALOpen())
+        return false;
+
+    // boot imu
+    if (!setCtrl3C())
+        return false;
+    // wait for boot to finish
+    usleep(100);
+
+    // set up the gyro/accel
+    if (!setCtrl1XL())
+        return false;
+
+    if (!setCtrl2G())
+        return false;
+
+    if (!setCtrl5c())
+        return false;
+    gyroBiasInit();
+
+    m_timeTagRolloverCount = 0;
+    m_timeTagBaseOffset = 0;
+    m_imuData.timestamp = 0;
+    dataRegRead();
+
+
+    return true;
+
+
+}
+
+int RTIMULSM6DSLLIS3MDL::IMUGetPollInterval()
+{
+    return 0;
+}
+
+bool RTIMULSM6DSLLIS3MDL::setCtrl1XL()
+{
+    if (!_readReg(CTRL1_XL, &m_ctrl1xl.value, 1, "Failed to read CTRL1_XL register"))
+        return false;
+
+    // Set the output data rate for the accelerometer
+    m_ctrl1xl.odr_XL = checkSettingsValue(
+        m_settings->m_LSM6DSLAccelSampleRate,
+        ODR_OFF,
+        ODR_6660,
+        LSM6DSL_ACCEL_SAMPLERATE_208,
+        RTIMULIB_LSM6DSL_ACCEL_SAMPLERATE
+    );
+
+    m_fusion->setAccelEnable(m_ctrl1xl.odr_XL > ODR_OFF);
+
+    // Set the full scale range for the accelerometer
+    m_ctrl1xl.fs_XL = checkSettingsValue(
+        m_settings->m_LSM6DSLAccelFSR,
+        FS_02G,
+        FS_08G,
+        LSM6DSL_ACCEL_FSR_2,
+        RTIMULIB_LSM6DSL_ACCEL_FSR
+    );
+
+    m_accelScale = ACCEL_FSR[m_ctrl1xl.fs_XL];
+
+    // Set the filter selection for the accelerometer
+    m_ctrl1xl.lpf1_bw_sel = checkSettingsValue(
+        m_settings->m_LSM6DSLAccelFilter2Select,
+        ACCEL_FILTER_SEL_BYPASS,
+        ACCEL_FILTER_SEL_HPF,
+        LSM6DSL_ACCEL_FILTER_BYPASS,
+        RTIMULIB_LSM6DSL_ACCEL_FILTER
+    ) > ACCEL_FILTER_SEL_BYPASS;
+
+    // Set the low pass filter for the accelerometer
+    m_ctrl1xl.bw0_XL = checkSettingsValue(
+        m_settings->m_LSM6DSLAccelLPFAn,
+        ACCEL_AAF_CUTOFF_1500,
+        ACCEL_AAF_CUTTOF_0400,
+        LSM6DSL_ACCEL_AN_LPF_1500,
+        RTIMULIB_LSM6DSL_ACCLE_LPFAn
+    );
+
+    return _writeReg(CTRL1_XL, m_ctrl1xl.value, "Failed to write CTRL1_XL register");
+}
+
+bool RTIMULSM6DSLLIS3MDL::setCtrl2G()
+{
+    if (!_readReg(CTRL2_G, &m_ctrl2g.value, 1, "Failed to read CTRL2_G register"))
+        return false;
+
+    // Set the output data rate for the gyroscope
+    m_ctrl2g.odr_G = checkSettingsValue(
+        m_settings->m_LSM6DSLGyroSampleRate,
+        ODR_OFF,
+        ODR_6660,
+        LSM6DSL_GYRO_SAMPLERATE_208,
+        RTIMULIB_LSM6DSL_GYRO_SAMPLERATE
+    );
+
+    m_fusion->setGyroEnable(m_ctrl2g.odr_G > ODR_OFF);
+    m_sampleRate = (1 << (m_ctrl2g.odr_G - 1)) * ODR_SCALE;
+
+    // Set the full scale range for the gyroscope
+    uint8_t tempFSR = checkSettingsValue(
+        m_settings->m_LSM6DSLGyroFSR,
+        FS_0125DPS,
+        FS_2000DPS,
+        LSM6DSL_GYRO_FSR_250,
+        RTIMULIB_LSM6DSL_GYRO_FSR
+    );
+    if (tempFSR - 1 < 0)
+        m_ctrl2g.fs_125 = 1;
+    else
+        m_ctrl2g.fs_G = tempFSR - 1;
+    m_gyroScale = GYRO_FSR[m_ctrl2g.fs_G] * RTMATH_DEGREE_TO_RAD;
+
+
+
+    return _writeReg(CTRL2_G, m_ctrl2g.value, "Failed to write CTRL2_G register");
+}
+
+bool RTIMULSM6DSLLIS3MDL::setCtrl3C()
+{
+    // read in chip defaults
+    if (!_readReg(CTRL3_C, &m_ctrl3c.value, 1, "Failed to read CTRL3_C register"))
+        return false;
+
+    m_ctrl3c.boot = 1;
+    // perform boot
+    if (!_writeReg(CTRL3_C, m_ctrl3c.value, "Failed to write CTRL3_C register for boot"))
+        return false;
+    usleep(2000); // 15 mS boot time
+
+    if (!_readReg(CTRL3_C, &m_ctrl3c.value, 1, "Failed to read CTRL3_C register after boot"))
+        return false;
+
+    m_ctrl3c.swReset = 1;
+    // perform reset
+    if (!_writeReg(CTRL3_C, m_ctrl3c.value, "Failed to write CTRL3_C register for reset"))
+        return false;
+    usleep(60); // 50 uS reset time
+
+    if (!_readReg(CTRL3_C, &m_ctrl3c.value, 1, "Failed to read CTRL3_C register after reset"))
+        return false;
+
+    // set up defaults
+    m_ctrl3c.bdu = 1;
+    m_ctrl3c.ifInc = 1;
+
+    return _writeReg(CTRL3_C, m_ctrl3c.value, "Failed to write CTRL3_C register");
+}
+
+bool RTIMULSM6DSLLIS3MDL::setCtrl5c()
+{
+    if (!_readReg(CTRL5_C, &m_ctrl5c.value, 1, "Failed to read CTRL5_C register"))
+        return false;
+    m_ctrl5c.rounding = 0x3;    // enable rounding on gyro & accel data
+
+    return _writeReg(CTRL5_C, m_ctrl5c.value, "Failed to write CTRL5_C register");
+}
+
+bool RTIMULSM6DSLLIS3MDL::setCtrl10c()
+{
+    if (!_readReg(CTRL10_C, &m_ctrl10c.value, 1, "Failed to read CTRL10_C register"))
+        return false;
+
+    m_ctrl10c.timer_en = 1;
+
+    return _writeReg(CTRL10_C, m_ctrl10c.value, "Failed to write CTRL10_C register");
+}
+
+bool RTIMULSM6DSLLIS3MDL::setWakeUpDur()
+{
+    if (!_readReg(WAKE_UP_DUR, &m_wakeUpDur.value, 1, "Failed to read WAKE_UP_DUR register"))
+        return false;
+    m_wakeUpDur.timer_hr = 1; // enable 25 uS lsb
+    return _writeReg(WAKE_UP_DUR, m_wakeUpDur.value, "Failed to write WAKE_UP_DUR register");
+}
+
+bool RTIMULSM6DSLLIS3MDL::dataRegRead()
+{
+    uint8_t rawData[OUTZ_H_XL - STATUS_REG + 1];
+
+    if (!_readReg(STATUS_REG, rawData, 1, "Failed to read data registers"))
+        return false;
+
+    if (!(rawData[0] & 3))
+        return false;
+
+    if (rawData[0] & 2) {
+        if (_readReg(OUTX_L_G, &rawData[4], OUTZ_H_G - OUTX_L_G + 1, "Failed to read gyro data"))    
+            RTMath::convertToVector(&rawData[4], m_imuData.gyro, m_gyroScale, false);
+    }
+    if (rawData[0] & 1){
+        if (_readReg(OUTX_L_XL, &rawData[10], OUTZ_H_XL - OUTX_L_XL + 1, "Failed to read accel data"))
+            RTMath::convertToVector(&rawData[10], m_imuData.accel, m_accelScale, false);
+    }
+
+    m_imuData.timestamp = RTMath::currentUSecsSinceEpoch();//processTimeStamp(((uint64_t)rawTime[2] << 16 | (uint64_t)rawTime[1] << 8 | rawTime[0]) * 25);
+
+    return true;
+}
+
+
+
+
+
+bool RTIMULSM6DSLLIS3MDL::IMURead()
+{
+    if (!dataRegRead())
+        return false;
+
+
+    // sort out gyro axes and correct for bias
+    m_imuData.gyro.setZ(-m_imuData.gyro.z());
+
+    //  sort out accel data;
+
+    m_imuData.accel.setX(-m_imuData.accel.x());
+    m_imuData.accel.setY(-m_imuData.accel.y());
+
+    //  now do standard processing
+
+    handleGyroBias();
+
+    calibrateAccel();
+
+    //  now update the filter
+
+    updateFusion();
+
+
+    return true;
+}

--- a/RTIMULib/IMUDrivers/RTIMULSM6DSLLIS3MDL.h
+++ b/RTIMULib/IMUDrivers/RTIMULSM6DSLLIS3MDL.h
@@ -1,0 +1,95 @@
+////////////////////////////////////////////////////////////////////////////
+//
+//  This file is part of RTIMULib
+//
+//  Copyright (c) 2014-2015, richards-tech, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+//  Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#ifndef _RTIMULSM6DSLLIS3MDL_H
+#define	_RTIMULSM6DSLLIS3MDL_H
+#include "RTIMU.h"
+#include "RTIMULSM6DSLMap.h"
+class RTIMULSM6DSLLIS3MDL : public RTIMU {
+    public:
+    RTIMULSM6DSLLIS3MDL(RTIMUSettings *settings);
+    ~RTIMULSM6DSLLIS3MDL();
+
+    virtual const char *IMUName() { return "LSM6DSL & LIS3MDL"; }
+    virtual int IMUType() { return RTIMU_TYPE_LSM6DSLLIS3MDL; }
+    virtual bool IMUInit();
+    virtual int IMUGetPollInterval();
+    virtual bool IMURead();
+
+
+    private:
+    uint8_t m_gyroAccelSlaveAddr;
+
+    RTFLOAT m_accelScale;
+    RTFLOAT m_gyroScale;
+
+      // Structs to store register values
+    LSM6DSL::CTRL1_XL_t m_ctrl1xl;
+    LSM6DSL::CTRL2_G_t m_ctrl2g;
+    LSM6DSL::CTRL3_C_t m_ctrl3c;
+    LSM6DSL::CTRL5_C_t m_ctrl5c;
+    LSM6DSL::CTRL10_C_t m_ctrl10c;
+    LSM6DSL::WAKE_UP_DUR_t m_wakeUpDur;
+
+    RTIMUFifoBuffer m_fifoCache;
+
+    uint64_t m_timeTagRolloverCount;
+    uint64_t m_timeTagBaseOffset;
+
+    // register setters
+    bool setCtrl1XL();
+    bool setCtrl2G();
+    bool setCtrl3C();
+
+    bool setCtrl5c();
+
+    bool setCtrl10c();
+
+    bool setWakeUpDur();
+
+    // data read helpers
+    bool fifoRead();
+    bool dataRegRead();
+
+
+
+
+    // read/write helpers
+    inline bool _writeReg(uint8_t reg, const uint8_t value, const char *errorMsg) { return m_settings->HALWrite(m_gyroAccelSlaveAddr, reg, value, errorMsg); }
+    inline bool _readReg(uint8_t reg, uint8_t *buffer, unsigned short length, const char *errorMsg) { return m_settings->HALRead(m_gyroAccelSlaveAddr, reg, length, buffer, errorMsg); }
+
+    inline int checkSettingsValue(int value, int min, int max, int failsafe, const char *registerName)
+    {
+        if (value < min || value > max) {
+            HAL_ERROR3("Invalid value %d for %s. Setting to default: %d\n", value, registerName, failsafe);
+            return failsafe;
+        }
+        return value;
+    }
+
+
+};
+
+
+#endif  // _RTIMULSM6DSLLIS3MDL_H

--- a/RTIMULib/IMUDrivers/RTIMULSM6DSLMap.h
+++ b/RTIMULib/IMUDrivers/RTIMULSM6DSLMap.h
@@ -1,0 +1,267 @@
+  ////////////////////////////////////////////////////////////////////////////
+  //
+  //  This file is part of RTIMULib
+  //
+  //  Copyright (c) 2014-2015, richards-tech, LLC
+  //
+  //  Permission is hereby granted, free of charge, to any person obtaining a copy of
+  //  this software and associated documentation files (the "Software"), to deal in
+  //  the Software without restriction, including without limitation the rights to use,
+  //  copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+  //  Software, and to permit persons to whom the Software is furnished to do so,
+  //  subject to the following conditions:
+  //
+  //  The above copyright notice and this permission notice shall be included in all
+  //  copies or substantial portions of the Software.
+  //
+  //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  //  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  //  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  //  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  //  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  //  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+#ifndef RTIMULSM6DSLMAP_H
+#define RTIMULSM6DSLMAP_H
+
+#include "RTIMU.h"
+
+namespace LSM6DSL {
+                                                                              // nice to have constants
+    constexpr RTFLOAT ACCEL_FSR[4] = { 6.1e-5, 4.88e-4, 2.44e-4, 1.22e-4 };   //G's/lsb
+    constexpr RTFLOAT GYRO_FSR[5] = { .004375, .00875, .01750, .035, .070 };  // dps/lsb
+    constexpr RTFLOAT ODR_SCALE =  13.0;                                     // Hz
+
+    // Register definitions
+    typedef struct _CTRL1_XL_t {
+        union {
+            struct {
+                uint8_t bw0_XL     : 1;
+                uint8_t lpf1_bw_sel: 1;
+                uint8_t fs_XL      : 2;
+                uint8_t odr_XL     : 4;
+            };
+            uint8_t value;
+        };
+    }CTRL1_XL_t;
+
+    typedef struct _CTRL2_G_t {
+        union {
+            struct {
+                uint8_t reserved: 1;
+                uint8_t fs_125  : 1;
+                uint8_t fs_G    : 2;
+                uint8_t odr_G   : 4;
+            };
+            uint8_t value;
+        };
+    }CTRL2_G_t;
+
+    typedef struct _CTRL3_C_t {
+        union {
+            struct {
+                uint8_t swReset  : 1;
+                uint8_t ble      : 1;
+                uint8_t ifInc    : 1;
+                uint8_t sim      : 1;
+                uint8_t pp_od    : 1;
+                uint8_t h_lactive: 1;
+                uint8_t bdu      : 1;
+                uint8_t boot     : 1;
+            };
+            uint8_t value;
+        };
+    }CTRL3_C_t;
+
+    typedef struct _CTRL5_C_t{
+        union{
+            struct{
+                uint8_t st_xl   : 2;
+                uint8_t st_g    : 2;
+                uint8_t den_lh  : 1;
+                uint8_t rounding: 3;
+            };
+            uint8_t value;
+        };
+    }CTRL5_C_t;
+
+    typedef struct _CTRL10_C_t{
+        union{
+            struct{
+                uint8_t sign_motion_en: 1;
+                uint8_t ped_rst_step  : 1;
+                uint8_t func_en       : 1;
+                uint8_t tilt_en       : 1;
+                uint8_t pedo_en       : 1;
+                uint8_t timer_en      : 1;
+                uint8_t wrist_tilt_en : 1;
+            };
+            uint8_t value;
+        };
+    }CTRL10_C_t;
+
+    typedef struct _WAKE_UP_DUR_t{
+        union{
+            struct{
+                uint8_t sleep_dur: 4;
+                uint8_t timer_hr : 1;
+                uint8_t wake_dur : 2;
+                uint8_t ff_dur   : 1;
+            };
+            uint8_t value;
+        };
+    }WAKE_UP_DUR_t;
+
+
+
+
+          // register map
+    enum {
+        FUNC_CFG_ACCESS          = 0x1,    // r/w
+        SENSOR_SYNC_TIME_FRAME   = 0x4,    // r/w
+        SENSOR_SYNC_RES_RATIO    = 0x5,    // r/w
+        FIFO_CTRL1               = 0x6,    // r/w
+        FIFO_CTRL2               = 0x7,    // r/w
+        FIFO_CTRL3               = 0x8,    // r/w
+        FIFO_CTRL4               = 0x9,    // r/w
+        FIFO_CTRL5               = 0x0A,   // r/w
+        DRDY_PULSE_CFG_G         = 0x0B,   // r/w
+        INT1_CTRL                = 0x0D,   // r/w
+        INT2_CTRL                = 0x0E,   // r/w
+        WHO_AM_I                 = 0x0F,   // r
+        CTRL1_XL                 = 0x10,   // r/w
+        CTRL2_G                  = 0x11,   // r/w
+        CTRL3_C                  = 0x12,   // r/w
+        CTRL4_C                  = 0x13,   // r/w
+        CTRL5_C                  = 0x14,   // r/w
+        CTRL6_C                  = 0x15,   // r/w
+        CTRL7_G                  = 0x16,   // r/w
+        CTRL8_XL                 = 0x17,   // r/w
+        CTRL9_XL                 = 0x18,   // r/w
+        CTRL10_C                 = 0x19,   // r/w
+        MASTER_CONFIG            = 0x1A,   // r/w
+        WAKE_UP_SRC              = 0x1B,   // r
+        TAP_SRC                  = 0x1C,   // r
+        D6D_SRC                  = 0x1D,   // r
+        STATUS_REG               = 0x1E,   // r
+        OUT_TEMP_L               = 0x20,   // r
+        OUT_TEMP_H               = 0x21,   // r
+        OUTX_L_G                 = 0x22,   // r
+        OUTX_H_G                 = 0x23,   // r
+        OUTY_L_G                 = 0x24,   // r
+        OUTY_H_G                 = 0x25,   // r
+        OUTZ_L_G                 = 0x26,   // r
+        OUTZ_H_G                 = 0x27,   // r
+        OUTX_L_XL                = 0x28,   // r
+        OUTX_H_XL                = 0x29,   // r
+        OUTY_L_XL                = 0x2A,   // r
+        OUTY_H_XL                = 0x2B,   // r
+        OUTZ_L_XL                = 0x2C,   // r
+        OUTZ_H_XL                = 0x2D,   // r
+        SENSORHUB1_REG           = 0x2E,   // r
+        SENSORHUB2_REG           = 0x2F,   // r
+        SENSORHUB3_REG           = 0x30,   // r
+        SENSORHUB4_REG           = 0x31,   // r
+        SENSORHUB5_REG           = 0x32,   // r
+        SENSORHUB6_REG           = 0x33,   // r
+        SENSORHUB7_REG           = 0x34,   // r
+        SENSORHUB8_REG           = 0x35,   // r
+        SENSORHUB9_REG           = 0x36,   // r
+        SENSORHUB10_REG          = 0x37,   // r
+        SENSORHUB11_REG          = 0x38,   // r
+        SENSORHUB12_REG          = 0x39,   // r
+        FIFO_STATUS1             = 0x3A,   // r
+        FIFO_STATUS2             = 0x3B,   // r
+        FIFO_STATUS3             = 0x3C,   // r
+        FIFO_STATUS4             = 0x3D,   // r
+        FIFO_DATA_OUT_L          = 0x3E,   // r
+        FIFO_DATA_OUT_H          = 0x3F,   // r
+        TIMESTAMP0_REG           = 0x40,   // r
+        TIMESTAMP1_REG           = 0x41,   // r
+        TIMESTAMP2_REG           = 0x42,   // r/w
+        STEP_TIMESTAMP_L         = 0x49,   // r
+        STEP_TIMESTAMP_H         = 0x4A,   // r
+        STEP_COUNTER_L           = 0x4B,   // r
+        STEP_COUNTER_H           = 0x4C,   // r
+        SENSORHUB13_REG          = 0x4D,   // r
+        SENSORHUB14_REG          = 0x4E,   // r
+        SENSORHUB15_REG          = 0x4F,   // r
+        SENSORHUB16_REG          = 0x50,   // r
+        SENSORHUB17_REG          = 0x51,   // r
+        SENSORHUB18_REG          = 0x52,   // r
+        FUNC_SRC1                = 0x53,   // r
+        FUNC_SRC2                = 0x54,   // r
+        WRIST_TILT_IA            = 0x55,   // r
+        TAP_CFG                  = 0x58,   // r/w
+        TAP_THS_6D               = 0x59,   // r/w
+        INT_DUR2                 = 0x5A,   // r/w
+        WAKE_UP_THS              = 0x5B,   // r/w
+        WAKE_UP_DUR              = 0x5C,   // r/w
+        FREE_FALL                = 0x5D,   // r/w
+        MD1_CFG                  = 0x5E,   // r/w
+        MD2_CFG                  = 0x5F,   // r/w
+        MASTER_CMD_CODE          = 0x60,   // r/w
+        SENS_SYNC_SPI_ERROR_CODE = 0x61,   // r/w
+        OUT_MAG_RAW_X_L          = 0x66,   // r
+        OUT_MAG_RAW_X_H          = 0x67,   // r
+        OUT_MAG_RAW_Y_L          = 0x68,   // r
+        OUT_MAG_RAW_Y_H          = 0x69,   // r
+        OUT_MAG_RAW_Z_L          = 0x6A,   // r
+        OUT_MAG_RAW_Z_H          = 0x6B,   // r
+        X_OFS_USR                = 0x73,   // r/w
+        Y_OFS_USR                = 0x74,   // r/w
+        Z_OFS_USR                = 0x75,   // r/w
+    };
+
+
+        // Selectable odr values
+    enum {
+        ODR_OFF    = 0,
+        ODR_0012_5 = 1,
+        ODR_0026   = 2,
+        ODR_0052   = 3,
+        ODR_0104   = 4,
+        ODR_0208   = 5,
+        ODR_0416   = 6,
+        ODR_0833   = 7,
+        ODR_1660   = 8,
+        ODR_3330   = 9,
+        ODR_6660   = 10
+    };
+
+        // Selectable accel fs values
+    enum {
+        FS_02G = 0,
+        FS_16G = 1,
+        FS_04G = 2,
+        FS_08G = 3,
+    };
+
+        // Selectable gyro fs values
+    enum {
+        FS_0125DPS = 0,
+        FS_0250DPS = 1,
+        FS_0500DPS = 2,
+        FS_1000DPS = 3,
+        FS_2000DPS = 4,
+    };
+
+        // accel filter config options
+    enum {
+        ACCEL_FILTER_SEL_BYPASS = 0,
+        ACCEL_FILTER_SEL_LPF2   = 1,
+        ACCEL_FILTER_SEL_HPF    = 2,
+    };
+
+    enum {
+        ACCEL_AAF_CUTOFF_1500 = 0,
+        ACCEL_AAF_CUTTOF_0400 = 1,
+    };
+};
+
+
+
+
+#endif  // RTIMULSM6DSLMAP_H

--- a/RTIMULib/IMUDrivers/RTIMULSM9DS1.cpp
+++ b/RTIMULib/IMUDrivers/RTIMULSM9DS1.cpp
@@ -145,9 +145,9 @@ bool RTIMULSM9DS1::IMUInit()
 
     m_imuData.fusionPoseValid = false;
     m_imuData.fusionQPoseValid = false;
-    m_imuData.gyroValid = m_settings->m_LSM9DS1PollMode > LSM9DS1_FAST_POLL_MODE_OFF;
-    m_imuData.accelValid = m_settings->m_LSM9DS1PollMode > LSM9DS1_FAST_POLL_MODE_OFF;
-    m_imuData.compassValid = m_settings->m_LSM9DS1PollMode > LSM9DS1_FAST_POLL_MODE_OFF;
+    m_imuData.gyroValid = m_settings->m_LSM9DS1GyroSampleRate > LSM9DS1_GYRO_HPF_OFF;
+    m_imuData.accelValid = m_settings->m_LSM9DS1AccelSampleRate > LSM9DS1_ACCEL_SAMPLERATE_OFF;
+    m_imuData.compassValid = m_settings->m_LSM9DS1CompassSampleRate > LSM9DS1_COMPASS_SAMPLERATE_OFF;
     m_imuData.pressureValid = false;
     m_imuData.temperatureValid = false;
     m_imuData.humidityValid = false;
@@ -183,7 +183,7 @@ bool RTIMULSM9DS1::setGyroSampleRate()
         m_sampleRate = 1e6 / m_sampleInterval;
     }
 
-    m_fusion->setCompassEnable(m_settings->m_LSM9DS1GyroSampleRate != LSM9DS1_GYRO_SAMPLERATE_OFF);
+    m_fusion->setGyroEnable(m_settings->m_LSM9DS1GyroSampleRate != LSM9DS1_GYRO_SAMPLERATE_OFF);
 
 
     m_settings->m_LSM9DS1GyroBW = checkSettingsValue(
@@ -610,11 +610,6 @@ bool RTIMULSM9DS1::IMURead()
 
 
     m_fifoBuff.pop();
-
-
-
-    m_imuData.temperature += !m_imuData.accelValid;
-    m_imuData.pressure += !m_imuData.gyroValid;
 
     processIMUData();
 

--- a/RTIMULib/IMUDrivers/RTIMULSM9DS1.cpp
+++ b/RTIMULib/IMUDrivers/RTIMULSM9DS1.cpp
@@ -143,16 +143,16 @@ bool RTIMULSM9DS1::IMUInit()
 
     // set validity flags
 
-    m_imuData.fusionPoseValid = false;
+    m_imuData.fusionPoseValid  = false;
     m_imuData.fusionQPoseValid = false;
-    m_imuData.gyroValid = m_settings->m_LSM9DS1GyroSampleRate > LSM9DS1_GYRO_HPF_OFF;
-    m_imuData.accelValid = m_settings->m_LSM9DS1AccelSampleRate > LSM9DS1_ACCEL_SAMPLERATE_OFF;
-    m_imuData.compassValid = m_settings->m_LSM9DS1CompassSampleRate > LSM9DS1_COMPASS_SAMPLERATE_OFF;
-    m_imuData.pressureValid = false;
+    m_imuData.gyroValid        = m_settings->m_LSM9DS1GyroSampleRate > LSM9DS1_GYRO_SAMPLERATE_OFF;
+    m_imuData.accelValid       = m_settings->m_LSM9DS1AccelSampleRate > LSM9DS1_ACCEL_SAMPLERATE_OFF;
+    m_imuData.compassValid     = m_settings->m_LSM9DS1CompassSampleRate > LSM9DS1_COMPASS_SAMPLERATE_OFF;
+    m_imuData.pressureValid    = false;
     m_imuData.temperatureValid = false;
-    m_imuData.humidityValid = false;
-    m_imuData.pressure = 0;
-    m_imuData.temperature = 0;
+    m_imuData.humidityValid    = false;
+    m_imuData.pressure         = 0;
+    m_imuData.temperature      = 0;
 
 
 
@@ -532,16 +532,25 @@ bool RTIMULSM9DS1::IMURead()
 {
     unsigned char compassData[7];   //1 byte for status 6, bytes for mag
     unsigned char sampleCount = 1;
+    unsigned char readLocation = 0;
 
     uint64_t now = RTMath::currentUSecsSinceEpoch();
-    bool magRead = m_settings->m_LSM9DS1CompassSampleRate != LSM9DS1_COMPASS_SAMPLERATE_OFF && now >= m_magODRInterval + m_lastMagRead && (m_settings->m_LSM9DS1PollMode != LSM9DS1_FIFO_CACHE_MODE || m_fifoBuff.getSampleSize() > 2);
-    bool cacheRead = m_settings->m_LSM9DS1PollMode != LSM9DS1_FIFO_CACHE_MODE || (!magRead && m_fifoBuff.frontTimeStampBase() + m_sampleInterval * M_IMU_FIFO_SIZE_MAX <= now);
 
-    // boot out if no read available in timed poll mode
+    bool isCompassSampleRateOn = m_settings->m_LSM9DS1CompassSampleRate != LSM9DS1_COMPASS_SAMPLERATE_OFF;
+    bool isTimeForMagRead = now >= m_magODRInterval + m_lastMagRead;
+    bool isFifoSampleSizeSufficient = m_settings->m_LSM9DS1PollMode != LSM9DS1_FIFO_CACHE_MODE || m_fifoBuff.getSampleSize() > 1;
+    bool isNotFifoCacheMode = m_settings->m_LSM9DS1PollMode != LSM9DS1_FIFO_CACHE_MODE;
+    bool isTimeForCacheRead = m_fifoBuff.frontTimeStampBase() + m_sampleInterval * M_IMU_FIFO_SIZE_MAX <= now;
+
+
+    bool magRead = isCompassSampleRateOn && isTimeForMagRead && isFifoSampleSizeSufficient;
+    bool cacheRead = isNotFifoCacheMode || (!magRead && isTimeForCacheRead);
+        // boot out if no read available in timed poll mode
     if (m_settings->m_LSM9DS1PollMode == LSM9DS1_TIMED_POLL_MODE && m_imuData.timestamp + m_sampleInterval > now)
         return false;
 
     if (cacheRead) {
+
         // read fifo src if doing any sort of caching
         if (m_settings->m_LSM9DS1PollMode == LSM9DS1_FIFO_CACHE_MODE) {
             if (!m_settings->HALRead(m_accelGyroSlaveAddr, LSM9DS1_FIFO_SRC, 1, &sampleCount, "Failed to read LSM9DS1 FIFO status"))
@@ -550,67 +559,48 @@ bool RTIMULSM9DS1::IMURead()
             if ((sampleCount &= 0x3f) == 0)
                 return false;
         }
-        // read gyro + accel
-        if (m_settings->m_LSM9DS1GyroSampleRate > LSM9DS1_GYRO_SAMPLERATE_OFF) {
-            if (!m_settings->HALRead(m_accelGyroSlaveAddr, LSM9DS1_STATUS + !m_imuReadPtr, sampleCount * m_imuSampleSize, m_fifoBuff.readIn(sampleCount * m_imuSampleSize), "Failed to read LSM9DS1 FIFO data"))
-                return false;
-        }
-        // accel only read
-        else {
-            if (!m_settings->HALRead(m_accelGyroSlaveAddr, LSM9DS1_STATUS2 + !m_imuReadPtr, sampleCount * m_imuSampleSize, m_fifoBuff.readIn(sampleCount * m_imuSampleSize), "Failed to read LSM9DS1 FIFO data"))
-                return false;
-        }
-    }
-    // read mag data
 
-    // only poll mag data if enabled and sampling interval has passed & enabled
+        unsigned short readsize = sampleCount * m_imuSampleSize;
+        unsigned char *buffer = m_fifoBuff.readIn(readsize);
+
+        if (m_settings->m_LSM9DS1GyroSampleRate > LSM9DS1_GYRO_SAMPLERATE_OFF)
+            // accel only read
+            readLocation = LSM9DS1_STATUS + !m_imuReadPtr;
+        else
+            // accel & gyro read
+            readLocation = LSM9DS1_STATUS2 + !m_imuReadPtr;
+
+        if (!m_settings->HALRead(m_accelGyroSlaveAddr, readLocation, readsize, buffer, "Failed to read LSM9DS1 FIFO data"))
+            return false;
+    }
+
     if (magRead) {
-        if (m_settings->HALRead(m_magSlaveAddr, LSM9DS1_MAG_STATUS + m_imuReadPtr, sizeof(compassData) - m_imuReadPtr, &compassData[m_imuReadPtr], "Failed to read LSM9DS1 compass data")) {
+        readLocation = LSM9DS1_MAG_STATUS + !m_imuReadPtr;
+        unsigned short readsize = sizeof(compassData) - !m_imuReadPtr;
+        if (m_settings->HALRead(m_magSlaveAddr, readLocation, readsize, &compassData[!m_imuReadPtr], "Failed to read LSM9DS1 compass data")) {
+
             if (!m_settings->m_LSM9DS1PollMode)
                 m_imuData.compassValid = compassData[0] & 0x08;
 
-            if (m_imuData.compassValid)
+            if (m_imuData.compassValid){
                 RTMath::convertToVector(&compassData[1], m_imuData.compass, m_compassScale, false);
 
-            //  sort out compass axes
-            m_imuData.compass.setX(-m_imuData.compass.x());
-            m_imuData.compass.setZ(-m_imuData.compass.z());
+                //  sort out compass axes
+                m_imuData.compass.setX(-m_imuData.compass.x());
+                m_imuData.compass.setZ(-m_imuData.compass.z());
 
-            if (!m_lastMagRead)
-                m_compassAverage = m_imuData.compass;
-            m_lastMagRead = now;
+                if (!m_lastMagRead)
+                    m_compassAverage = m_imuData.compass;
+                m_lastMagRead = now;
 
-            calibrateAverageCompass();
+                calibrateAverageCompass();
+            }
         }
     }
 
-
-    // process buffer
-    if (m_fifoBuff.isempty())
+    // false means there's no imu data in the cache :(
+    if (!processCache(magRead))
         return false;
-
-    // pop until buffer has one sample set left or the oldest sample is within the sample interval
-    while (m_fifoBuff.getSampleSize() > 1 && m_fifoBuff.frontTimeStamp(m_sampleInterval) + m_sampleInterval / 4 <= now)
-        m_fifoBuff.pop();
-
-
-    // convert data
-    if (m_settings->m_LSM9DS1GyroSampleRate > LSM9DS1_GYRO_SAMPLERATE_OFF) {
-        RTMath::convertToVector(m_fifoBuff.front() + m_imuReadPtr, m_imuData.gyro, m_gyroScale, false);
-        RTMath::convertToVector(m_fifoBuff.front() + m_imuReadPtr + M_SENSOR_3_AXIS_BYTE_SIZE, m_imuData.accel, m_accelScale, false);
-    } else
-        RTMath::convertToVector(m_fifoBuff.front() + m_imuReadPtr, m_imuData.accel, m_accelScale, false);
-
-    m_imuData.timestamp = m_fifoBuff.frontTimeStamp(m_sampleInterval);
-
-    if (m_imuReadPtr) {
-        m_imuData.accelValid = *(m_fifoBuff.front()) & 0x01;
-        m_imuData.gyroValid = *(m_fifoBuff.front()) & 0x02;
-    }
-
-
-    m_fifoBuff.pop();
-
     processIMUData();
 
     return true;
@@ -638,5 +628,57 @@ void RTIMULSM9DS1::processIMUData()
     //  now update the filter
 
     updateFusion();
+}
+
+bool RTIMULSM9DS1::processCache(bool magRead)
+{
+    if (m_fifoBuff.isempty())
+        return false;
+        
+    RTVector3 accelTemp(0, 0, 0);
+    RTVector3 gyroTemp(0, 0, 0);
+    RTVector3 accelSum(0, 0, 0);
+    RTVector3 gyroSum(0, 0, 0);
+    RTFLOAT DTsum = 0;
+    RTFLOAT dt;
+    bool readOnce = true;
+    // take weighted average of new data    
+    while (m_fifoBuff.getSampleSize() > 1 || readOnce) {
+
+        if (m_imuReadPtr) {
+            m_imuData.gyroValid = *(m_fifoBuff.front()) & 0x2;
+            m_imuData.accelValid = *(m_fifoBuff.front()) & 0x1;
+        }
+
+        dt = (m_fifoBuff.frontTimeStamp(m_sampleInterval) - m_imuData.timestamp)/1e6;
+        if (m_settings->m_LSM9DS1GyroSampleRate > LSM9DS1_GYRO_SAMPLERATE_OFF) {
+            RTMath::convertToVector(m_fifoBuff.front() + m_imuReadPtr, gyroTemp, m_gyroScale, false);
+            RTMath::convertToVector(m_fifoBuff.front() + m_imuReadPtr + M_SENSOR_3_AXIS_BYTE_SIZE, accelTemp, m_accelScale, false);
+        } else
+            RTMath::convertToVector(m_fifoBuff.front() + m_imuReadPtr, accelTemp, m_accelScale, false);
+
+        DTsum += dt;
+        accelSum += (accelTemp * dt);
+        gyroSum += (gyroTemp * dt);
+
+        m_fifoBuff.pop();
+        
+        if (!(m_imuData.gyroValid || m_imuData.accelValid))
+            return false;
+
+        readOnce = false;
+    }
+
+    
+    accelSum /= DTsum;
+    gyroSum /= DTsum;
+
+    m_imuData.accel = accelSum;
+    m_imuData.gyro = gyroSum;
+
+    m_imuData.timestamp = m_fifoBuff.frontTimeStamp(m_sampleInterval);
+
+    return true;
+
 }
 

--- a/RTIMULib/IMUDrivers/RTIMULSM9DS1.h
+++ b/RTIMULib/IMUDrivers/RTIMULSM9DS1.h
@@ -70,6 +70,7 @@ private:
     }
 
     void processIMUData();
+    bool processCache(bool readOnce);
 
     static constexpr int M_SAMPLERATE_SCALAR = 952; // 952 Hz
     static constexpr int M_MAG_SAMPLERATE_SCALAR = 80; // 80 Hz

--- a/RTIMULib/IMUDrivers/RTIMULSM9DS1.h
+++ b/RTIMULib/IMUDrivers/RTIMULSM9DS1.h
@@ -75,9 +75,9 @@ private:
     static constexpr int M_SAMPLERATE_SCALAR = 952; // 952 Hz
     static constexpr int M_MAG_SAMPLERATE_SCALAR = 80; // 80 Hz
     // one would think that the sensor scale factors are a function of the fsr, but they are not for some wild reason
-    static constexpr RTFLOAT M_GYRO_SCALE_LOOKUP[4] = {.00875, .0175 , 0, .070 }; // 245, 500, 2000 dps
-    static constexpr RTFLOAT M_ACCEL_SCALE_LOOKUP[4] = {.000061, .000732, .000122, .000244 }; // 2, 16, 4, 8 g
-    static constexpr RTFLOAT M_COMPASS_SCALE_LOOKUP[4] = {.00014, .00029, .00043, .00058 }; // 4, 8, 12, 16 gauss  
+    const RTFLOAT M_GYRO_SCALE_LOOKUP[4] = {.00875, .0175 , 0, .070 }; // 245, 500, 2000 dps
+    const RTFLOAT M_ACCEL_SCALE_LOOKUP[4] = {.000061, .000732, .000122, .000244 }; // 2, 16, 4, 8 g
+    const RTFLOAT M_COMPASS_SCALE_LOOKUP[4] = {.00014, .00029, .00043, .00058 }; // 4, 8, 12, 16 gauss  
     
     static constexpr unsigned int M_SENSOR_3_AXIS_BYTE_SIZE = 6;    // size of 3 axis data in bytes (2 bytes per axis, applies for accel, gyro, and compass)
     static constexpr unsigned int M_IMU_FIFO_SIZE_MAX = 3;         // max number of fifo slots per sensor axis

--- a/RTIMULib/RTFusion.cpp
+++ b/RTIMULib/RTFusion.cpp
@@ -34,7 +34,8 @@
 const char *RTFusion::m_fusionNameMap[] = {
     "NULL",
     "Kalman STATE4",
-    "RTQF"};
+    "RTQF",
+    "RTComplimentary"};
 
 RTFusion::RTFusion()
 {

--- a/RTIMULib/RTFusionComplimentary.cpp
+++ b/RTIMULib/RTFusionComplimentary.cpp
@@ -1,0 +1,134 @@
+////////////////////////////////////////////////////////////////////////////
+//
+//  This file is part of RTIMULib
+//
+//  Copyright (c) 2014-2015, richards-tech, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+//  Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+#include "RTFusionComplimentary.h"
+
+
+
+RTFusionComplimentary::RTFusionComplimentary()
+{
+    m_gyroAlphaThreshold = M_GYRO_FILTER_THRESHOLD;
+    m_accelAlphaThreshold = M_ACCEL_FILTER_THRESHOLD;
+}
+
+
+void RTFusionComplimentary::reset()
+{}
+
+void RTFusionComplimentary::predict()
+{
+    if (!m_enableGyro)
+        return;
+
+    RTFLOAT x2, y2, z2;
+    RTFLOAT qs, qx, qy, qz;
+
+    qs = m_stateQ.scalar();
+    qx = m_stateQ.x();
+    qy = m_stateQ.y();
+    qz = m_stateQ.z();
+
+    x2 = m_gyro.x() / (RTFLOAT)2.0;
+    y2 = m_gyro.y() / (RTFLOAT)2.0;
+    z2 = m_gyro.z() / (RTFLOAT)2.0;
+
+    // Predict new state
+
+    m_stateQ.setScalar(qs + (-x2 * qx - y2 * qy - z2 * qz) * m_timeDelta);
+    m_stateQ.setX(qx + (x2 * qs + z2 * qy - y2 * qz) * m_timeDelta);
+    m_stateQ.setY(qy + (y2 * qs - z2 * qx + x2 * qz) * m_timeDelta);
+    m_stateQ.setZ(qz + (z2 * qs + y2 * qx - x2 * qy) * m_timeDelta);
+    m_stateQ.normalize();
+}
+
+void RTFusionComplimentary::update()
+{
+    if (m_enableAccel) {
+        m_filterAlpha = (m_accel.length() - 1.);
+        m_filterAlpha = m_filterAlpha < 0 ? -1.0 * m_filterAlpha : m_filterAlpha;
+
+        if (m_filterAlpha < m_accelAlphaThreshold)
+            m_filterAlpha = 0.;
+        else if (m_filterAlpha > m_gyroAlphaThreshold)
+            m_filterAlpha = 1.;
+        else
+            m_filterAlpha = 1 / (m_gyroAlphaThreshold - m_accelAlphaThreshold) * (m_filterAlpha - m_accelAlphaThreshold);
+
+        // copy predicted state to fusion pose
+        m_stateQ.toEuler(m_fusionPose);
+
+        // interpolate the euler angles between fusion pose & measured pose based on the adaptive gain.
+        for (int i = 0; i < 3; i++)
+            m_fusionPose.setData(i, m_measuredPose.data(i) * (1. - m_filterAlpha) + m_fusionPose.data(i) * m_filterAlpha);
+
+        m_fusionQPose.fromEuler(m_fusionPose);
+    }
+}
+
+void RTFusionComplimentary::newIMUData(RTIMU_DATA &data, const RTIMUSettings *settings)
+{
+    if (m_debug) {
+        HAL_INFO("\n------\n");
+        HAL_INFO2("IMU update delta time: %f, sample %d\n", m_timeDelta, m_sampleNumber++);
+    }
+    m_sampleNumber++;
+
+    if (m_enableGyro)
+        m_gyro = data.gyro;
+    else
+        m_gyro = RTVector3();
+    m_accel = data.accel;
+    m_compass = data.compass;
+    m_compassValid = data.compassValid;
+
+    if (m_firstTime) {
+        m_lastFusionTime = data.timestamp;
+        calculatePose(m_accel, m_compass, settings->m_compassAdjDeclination);
+
+        //  initialize the poses
+
+        m_stateQ.fromEuler(m_measuredPose);
+        m_fusionQPose = m_stateQ;
+        m_fusionPose = m_measuredPose;
+        m_firstTime = false;
+
+    } else {
+        m_timeDelta = (RTFLOAT)(data.timestamp - m_lastFusionTime) / (RTFLOAT)1000000;
+        m_lastFusionTime = data.timestamp;
+        if (m_timeDelta <= 0)
+            return;
+
+        predict();
+        // measure
+        calculatePose(m_accel, m_compass, settings->m_compassAdjDeclination);
+
+        update();
+
+        data.fusionPose = m_fusionPose;
+        data.fusionQPose = m_fusionQPose;
+
+    }
+
+}

--- a/RTIMULib/RTFusionComplimentary.h
+++ b/RTIMULib/RTFusionComplimentary.h
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////
+//
+//  This file is part of RTIMULib
+//
+//  Copyright (c) 2014-2015, richards-tech, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of
+//  this software and associated documentation files (the "Software"), to deal in
+//  the Software without restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+//  Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+//  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+//  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+#ifndef _RTCOMPLIMENTARY_H_
+#define _RTCOMPLIMENTARY_H_
+
+#include "RTFusion.h"
+#include "RTIMUSettings.h"
+
+class RTFusionComplimentary : public RTFusion{
+public:
+    RTFusionComplimentary();
+    // ~RTFusionComplimentary();
+
+    int fusionType() { return RTFUSION_TYPE_COMPLIMENTARY; }
+    void reset();
+    void newIMUData(RTIMU_DATA& data, const RTIMUSettings *settings);
+
+    inline void setGyroAlphaThreshold(RTFLOAT t1) { m_gyroAlphaThreshold = t1; }
+    inline void setAccelAlphaThreshold(RTFLOAT t2) { m_accelAlphaThreshold = t2; }
+    
+private:
+    static constexpr RTFLOAT M_ACCEL_FILTER_THRESHOLD = 0.2;
+    static constexpr RTFLOAT M_GYRO_FILTER_THRESHOLD = 0.3;
+
+    void predict();
+    void update();
+
+    RTFLOAT m_filterAlpha;
+    RTFLOAT m_gyroAlphaThreshold;
+    RTFLOAT m_accelAlphaThreshold;
+
+    RTVector3 m_gyro;										// unbiased gyro data
+    RTFLOAT m_timeDelta;                                    // time between predictions
+
+    RTQuaternion m_stateQ;									// quaternion state vector
+
+    int m_sampleNumber;                                     // number of samples accumulated
+
+};
+
+
+#endif // _RTCOMPLIMENTARY_H_

--- a/RTIMULib/RTIMULibDefs.h
+++ b/RTIMULib/RTIMULibDefs.h
@@ -35,8 +35,9 @@
 #define RTFUSION_TYPE_NULL                  0                   // just a dummy to keep things happy if not needed
 #define RTFUSION_TYPE_KALMANSTATE4          1                   // kalman state is the quaternion pose
 #define RTFUSION_TYPE_RTQF                  2                   // RT quaternion fusion
+#define RTFUSION_TYPE_COMPLIMENTARY         3                   // complimentary sensor fusion
 
-#define RTFUSION_TYPE_COUNT                 3                   // number of fusion algorithm types
+#define RTFUSION_TYPE_COUNT                 4                   // number of fusion algorithm types
 
 //  This is a convenience structure that can be used to pass IMU data around
 

--- a/RTIMULib/RTIMUSettings.h
+++ b/RTIMULib/RTIMUSettings.h
@@ -192,11 +192,30 @@
 #define RTIMULIB_ACCELCAL_MAXZ              "AccelCalMaxZ"
 
 
-class RTIMUSettings : public RTIMUHal
-{
-public:
+// LSM6DSL Settings
 
-    //  Standard constructor sets up for ini file in working directory
+#define RTIMULIB_LSM6DSL_GYRO_SAMPLERATE    "LSM6DSLGyroSampleRate"
+#define RTIMULIB_LSM6DSL_GYRO_FSR           "LSM6DSLGyroFSR"
+#define RTIMULIB_LSM6DSL_GYRO_LPF1          "LSM6DSLGyroLPF1"
+#define RTIMULIB_LSM6DSL_GYRO_HPF           "LSM6DSLGyroHPF"
+
+#define RTIMULIB_LSM6DSL_ACCEL_SAMPLERATE   "LSM6DSLAccelSampleRate"
+#define RTIMULIB_LSM6DSL_ACCEL_FSR          "LSM6DSLAccelFSR"
+#define RTIMULIB_LSM6DSL_ACCLE_LPFAn        "LSM6DSLAccelLPFAn"
+#define RTIMULIB_LSM6DSL_ACCEL_LPF1         "LSM6DSLAccelLPF1"
+#define RTIMULIB_LSM6DSL_ACCEL_FILTER       "LSM6DSLAccelFilter2Select"
+
+
+#define RTIMULIB_LSM6DSL_POLLING_MODE       "LSM6DSLPollMode"
+
+#define RTIMULIB_LSM6DSL_FIFO_MODE          "LSM6DSLFifoMode"
+#define RTIMULIB_LSM6DSL_FIFO_SAMPLE_RATE   "LSM6DSLFifoSampleRate"
+
+
+class RTIMUSettings : public RTIMUHal {
+    public:
+
+        //  Standard constructor sets up for ini file in working directory
 
     RTIMUSettings(const char *productType = "RTIMULib");
 
@@ -207,17 +226,17 @@ public:
     //  This function tries to find an IMU. It stops at the first valid one
     //  and returns true or else false
 
-    bool discoverIMU(int& imuType, bool& busIsI2C, unsigned char& slaveAddress);
+    bool discoverIMU(int &imuType, bool &busIsI2C, unsigned char &slaveAddress);
 
     //  This function tries to find a pressure sensor. It stops at the first valid one
     //  and returns true or else false
 
-    bool discoverPressure(int& pressureType, unsigned char& pressureAddress);
+    bool discoverPressure(int &pressureType, unsigned char &pressureAddress);
 
     //  This function tries to find a humidity sensor. It stops at the first valid one
     //  and returns true or else false
 
-    bool discoverHumidity(int& humidityType, unsigned char& humidityAddress);
+    bool discoverHumidity(int &humidityType, unsigned char &humidityAddress);
 
     //  This function sets the settings to default values.
 
@@ -361,7 +380,26 @@ public:
 
     int m_BMX055MagPreset;                                  // the mag preset code
 
-private:
+
+    // LSM6DSL
+
+    int m_LSM6DSLGyroSampleRate;                            // the gyro sample rate
+    int m_LSM6DSLGyroFSR;                                   // the gyro full scale range
+    int m_LSM6DSLGyroLPF1;                                  // the gyro low pass filter
+    int m_LSM6DSLGyroHPF;                                   // the gyro high pass filter
+
+    int m_LSM6DSLAccelSampleRate;                           // the accel sample rate
+    int m_LSM6DSLAccelFSR;                                  // the accel full scale range
+    int m_LSM6DSLAccelLPFAn;                                // the accel analog low pass filter
+    int m_LSM6DSLAccelLPF1;                                 // the accel low pass filter
+    int m_LSM6DSLAccelFilter2Select;                        // the accel filter 2 selection
+
+    int m_LSM6DSLPollMode;                                  // poll mode selection
+
+    int m_LSM6DSLFifoMode;                                  // the fifo mode selection
+    int m_LSM6DSLFifoSampleRate;                            // the fifo sample rate
+
+    private:
     void setBlank();
     void setComment(const char *comment);
     void setValue(const char *key, const bool val);

--- a/RTIMULib/RTMath.cpp
+++ b/RTIMULib/RTMath.cpp
@@ -197,6 +197,20 @@ const RTVector3& RTVector3::operator -=(RTVector3& vec)
     return *this;
 }
 
+const RTVector3 &RTVector3::operator/=(RTFLOAT val)
+{
+    for (int i = 0; i < 3; i++)
+        m_data[i] /= val;
+    return *this;
+}
+
+RTVector3 &RTVector3::operator*(RTFLOAT val)
+{
+    for (int i = 0; i < 3; i++)
+        m_data[i] *= val;
+    return *this;
+}
+
 void RTVector3::zero()
 {
     for (int i = 0; i < 3; i++)

--- a/RTIMULib/RTMath.h
+++ b/RTIMULib/RTMath.h
@@ -86,7 +86,8 @@ public:
 
     const RTVector3&  operator +=(RTVector3& vec);
     const RTVector3&  operator -=(RTVector3& vec);
-
+    const RTVector3&  operator /= (RTFLOAT val);
+    RTVector3& operator *(RTFLOAT val);
     RTVector3& operator =(const RTVector3& vec);
 
     RTFLOAT length();


### PR DESCRIPTION
- added basic LSM6DSL support. Only non-fifo polling currently supported. 
- added RTFusionComplimentary class, which provides a simple complimentary filter with a dynamic filter gain based on the magnitude of the measured acceleration
- tweaked/fixed some issues with the lsm9ds1 driver